### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,90 +1,118 @@
-name: Trevas TS CI
-
-on: [push, pull_request]
+name: ci
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-    test-build:
-        name: Test & build
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 22
-            - run: yarn
-            # Build modules
-            - run: yarn build
-            # Build sonar reports
-            - run: yarn test --coverage
-            - name: Upload deploy artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: coverage
-                  path: coverage/
 
-    sonarcloud:
-        runs-on: ubuntu-latest
-        needs: test-build
-        if: (github.repository == 'InseeFr/Trevas-TS' && (
-            github.event_name == 'push') || (
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.fork == false
-            ))
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-            - name: Download coverage artifact
-              uses: actions/download-artifact@v4
-              with:
-                  name: coverage
-                  path: coverage
-            - name: SonarCloud Scan
-              uses: sonarsource/sonarcloud-github-action@master
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  test_lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+    - uses: bahmutov/npm-install@v1
+    - name: If this step fails run 'npm run lint' and 'npm run format' then commit again.
+      run: |
+        npm run lint:check
+        npm run format:check
+  test:
+    runs-on: ubuntu-latest
+    needs: test_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+    - uses: bahmutov/npm-install@v1
+    - run: npm run build
+    - run: npm run test
 
-    build-assets:
-        if: github.ref == 'refs/heads/master'
-        runs-on: ubuntu-latest
-        needs: sonarcloud
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 22
-            - run: yarn
-            # Build modules
-            - run: yarn build
-            # Build Storybook
-            - run: yarn build-storybook
-            - run: mkdir -p deploy/storybook
-            - run: cp -R ./storybook-static. ./deploy/storybook
-            # Build documentation
-            - run: |
-                  yarn install --frozen-lockfile
-                  yarn build
-              working-directory: ./docs/
-            - run: mkdir -p deploy/docs
-            - run: cp -R ./docs/build/. ./deploy/docs
-            - name: Upload deploy artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: deploy
-                  path: deploy/
+  check_if_version_upgraded:
+    name: Check if version upgrade
+    # When someone forks the repo and opens a PR we want to enables the tests to be run (the previous jobs)
+    # but obviously only us should be allowed to release.
+    # In the following check we make sure that we own the branch this CI workflow is running on before continuing.
+    # Without this check, trying to release would fail anyway because only us have the correct secret.NPM_TOKEN but
+    # it's cleaner to stop the execution instead of letting the CI crash.
+    if: |
+      github.event_name == 'push' || 
+      github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login 
+    runs-on: ubuntu-latest
+    needs: test
+    outputs:
+      from_version: ${{ steps.step1.outputs.from_version }}
+      to_version: ${{ steps.step1.outputs.to_version }}
+      is_upgraded_version: ${{ steps.step1.outputs.is_upgraded_version }}
+      is_pre_release: ${{steps.step1.outputs.is_pre_release }}
+    steps:
+    - uses: garronej/ts-ci@v2.1.5
+      id: step1
+      with: 
+        action_name: is_package_json_version_upgraded
+        branch: ${{ github.head_ref || github.ref }}
 
-    deploy:
-        if: github.ref == 'refs/heads/master'
-        runs-on: ubuntu-latest
-        needs: build-assets
-        steps:
-            - name: Download deploy artifact
-              uses: actions/download-artifact@v4
-              with:
-                  name: deploy
-            - name: Deploy
-              uses: peaceiris/actions-gh-pages@v4
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  publish_dir: .
+  create_github_release:
+    runs-on: ubuntu-latest
+    # We create release only if the version in the package.json have been upgraded and this CI is running against the main branch.
+    # We allow branches with a PR open on main to publish pre-release (x.y.z-rc.u) but not actual releases.
+    if: |
+      needs.check_if_version_upgraded.outputs.is_upgraded_version == 'true' &&
+      (
+        github.event_name == 'push' ||
+        needs.check_if_version_upgraded.outputs.is_pre_release == 'true'
+      )
+    needs: 
+      - check_if_version_upgraded
+    steps:
+    - uses: softprops/action-gh-release@v2
+      with:
+        name: Release v${{ needs.check_if_version_upgraded.outputs.to_version }}
+        tag_name: v${{ needs.check_if_version_upgraded.outputs.to_version }}
+        target_commitish: ${{ github.head_ref || github.ref }}
+        generate_release_notes: true
+        draft: false
+        prerelease: ${{ needs.check_if_version_upgraded.outputs.is_pre_release == 'true' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+  publish_on_npm:
+    runs-on: ubuntu-latest
+    needs: 
+      - create_github_release
+      - check_if_version_upgraded
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+    - uses: actions/setup-node@v4
+      with:
+        registry-url: https://registry.npmjs.org/
+    - uses: bahmutov/npm-install@v1
+    - run: npm run build
+    - run: npx -y -p denoify@1.6.16 enable_short_npm_import_path
+      env:
+        DRY_RUN: "0"
+    - uses: garronej/ts-ci@v2.1.5
+      with: 
+        action_name: remove_dark_mode_specific_images_from_readme
+    - name: Publishing on NPM
+      run: |
+        if [ "$(npm show . version)" = "$VERSION" ]; then
+          echo "This version is already published"
+          exit 0
+        fi
+        if [ "$NODE_AUTH_TOKEN" = "" ]; then
+          echo "Can't publish on NPM, You must first create a secret called NPM_TOKEN that contains your NPM auth token. https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets"
+          false
+        fi
+        EXTRA_ARGS=""
+        if [ "$IS_PRE_RELEASE" = "true" ]; then
+            EXTRA_ARGS="--tag next"
+        fi
+        npm publish $EXTRA_ARGS
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        VERSION: ${{ needs.check_if_version_upgraded.outputs.to_version }}
+        IS_PRE_RELEASE: ${{ needs.check_if_version_upgraded.outputs.is_pre_release }}


### PR DESCRIPTION
I've removed sonarlint and storybook jobs.  

I can reintroduce them if you want but I didn't do it because nowedays I don't think sonarcloud needs any perticuar actions. It can simply be integrated as a GitHub App and subscribe to the repo events.   

And regarding storybook you already have some legacy gitbook files on the ghpage branch so I don't want to ovewrite it.  

For releasing it's as usal, you bump the version number. 